### PR TITLE
Fix dead link

### DIFF
--- a/WSL/tutorials/wsl-vscode.md
+++ b/WSL/tutorials/wsl-vscode.md
@@ -97,7 +97,7 @@ The new Windows Terminal enables multiple tabs (quickly switch between Command P
 
 * [VS Code Remote Development](https://code.visualstudio.com/docs/remote/remote-overview)
 * [Remote development tips and tricks](https://code.visualstudio.com/docs/remote/troubleshooting)
-* [Remote development with WSL tutorial](https://code.visualstudio.com/remote-tutorials/wsl/getting-started)
+* [Remote development with WSL tutorial](https://code.visualstudio.com/docs/remote/wsl-tutorial)
 * [Using Docker with WSL 2 and VS Code](https://code.visualstudio.com/blogs/2020/03/02/docker-in-wsl2)
 * [Using C++ and WSL in VS Code](https://code.visualstudio.com/docs/cpp/config-wsl)
 * [Remote R Service for Linux](/visualstudio/rtvs/setting-up-remote-r-service-on-linux)


### PR DESCRIPTION
The removed link ("Remote development with WSL tutorial") leads to a 404 page that says: "Sorry! It seems the page can't be found".